### PR TITLE
Add web3vacancy to Web3 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@
 - [Medium Web3 Topics](https://medium.com/tag/web3) - Medium 上关于 Web3 的讨论
 - [FreeCodeCamp](https://www.freecodecamp.org/learn/blockchain-development/) - 大量免费 Web3 教程、视频、实战，适合快速入门查阅
 - [Alchemy University](https://university.alchemy.com) - S→以太坊→智能合约→DApp 全栈，12 个实战项目（NFT 画廊、DEX 等）
+- [web3vacancy](https://web3vacancy.com) - Web3 / 加密货币工作机会平台，聚合 DeFi、L2、钱包、安全等领域 2,400+ 实时职位，包含薪资数据、职业路径指南和面试资源
 
 ### DApp & Solidity 智能合约学习资源
 - [CryptoZombies](https://cryptozombies.io/) - 通过游戏形式学习 Solidity，非常适合初学者


### PR DESCRIPTION
Adds [web3vacancy](https://web3vacancy.com) to the Web3 其他综合学习资源 section. web3vacancy 是一个聚合 2,400+ 实时 Web3 和加密货币工作机会的平台，覆盖 DeFi、L2 网络、钱包、安全审计和基础设施等领域，并提供薪资数据、职业路径指南和面试资源。

web3vacancy is a web3 and crypto jobs platform aggregating 2,400+ live listings from DeFi protocols, L2 networks, wallets, security firms, and infrastructure companies. Includes salary benchmarks, career path guides, and interview prep — useful both as a hiring channel and a learning resource for the Chinese-speaking Web3 community.