### PR TITLE
Add Pharos to data tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@
 - [Glassnode](https://glassnode.com/) - 强大的链上数据分析及周报
 - [Coinglass](https://www.coinglass.com) - 合约持仓、灰度持仓、资金费率
 - [CryptoBubbles](https://cryptobubbles.net) - 前500加密货币活跃度气泡图
+- [Pharos](https://pharos.watch) - 开源稳定币分析仪表盘，追踪挂钩压力、DEX流动性、安全评分和黑名单事件
 
 ### 指数查询
 - [Google Trends](https://trends.google.com/trends) - 谷歌搜索趋势


### PR DESCRIPTION
添加 [Pharos](https://pharos.watch) 到「链上数据」分类。

Pharos 是一个开源稳定币分析仪表盘，追踪挂钩压力、DEX流动性、安全评分和黑名单事件，覆盖 391 个稳定币，数据源来自 DefiLlama、链上合约事件等。