### PR TITLE
新增 Cabal-Hunter（Solana cabal/rug 检测）

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@
 - [Bloxy](https://bloxy.info/zh/) - 区块链实时报告，DEX交易和套利分析
 - [DEFI-LAB](https://defi-lab.xyz/) - DeFi策略模拟器
 - [RugScreen](https://www.rugscreen.com/) - 土狗合约地址检查
+- [Cabal-Hunter](https://api.cabal-hunter.com/) - Solana cabal/rug 检测：追踪同源供资钱包、同区块 bundle 与协同砸盘，买入前判断你是否是 exit liquidity
 - [CypherHunter](https://www.cypherhunter.com/zh-hans/) - 项目及团队探索
 - [Notion](https://notionchina.co/guide/) - 笔记、任务、数据库和看板应用
 - [Ethereum Gas tracker](https://www.useweb3.xyz/gas?source=ethgas.watch&amp;referrer=ethgas.watch) - 聚合gas价格提要


### PR DESCRIPTION
在「实用工具」分类下、紧邻 RugScreen 新增 [Cabal-Hunter](https://api.cabal-hunter.com/)。

面向 Solana 的 cabal/rug 检测工具：追踪同源供资的钱包簇、同区块 bundle 与协同砸盘，在买入前判断你是否会成为 exit liquidity。提供免费可视化 bubble map，以及供 bot/agent 调用的 API 与 MCP。合约干净不等于 cabal 干净。