### PR TITLE
添加 VaultVision 到数据工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@
 - [DappRadar](https://dappradar.com/) - 项目分析、市场分析工具
 - [Apy](https://apy.vision/) - 多功能流动性池分析和收益率跟踪工具
 - [Parsec](https://parsec.finance/) - 专业分析图表工具，高度可配置市场数据流，包括交易、借贷和清算
+- [VaultVision](https://vaultvision.tech/vaults/scanner) - 免费只读的 Hyperliquid 金库扫描器，对比 TVL、风险、回撤、存款状态和入场质量；用于研究和手动跟踪，不自动执行交易
 - [Cryptoquant](https://cryptoquant.com/asset/btc/chart/exchange-flows) - 行情分析及链上数据分析
 - [Merv](https://merv.tech/) - defi链上数据分析
 - [Tokensniffer](https://tokensniffer.com/) - 土狗meme币信息查询


### PR DESCRIPTION
将 VaultVision 添加到「数据工具 > 综合查询」。

VaultVision 是免费的只读 Hyperliquid 金库扫描器，可对比 TVL、风险、最大回撤、存款状态和入场质量。该条目明确说明仅用于研究和手动跟踪，不提供自动交易执行，也不包含推荐链接或未经验证的收益承诺。

提交前已确认目标页面返回 HTTP 200。